### PR TITLE
Use Advanced Python Scheduler to schedule digests (instead of celery.beat)

### DIFF
--- a/notifier/management/commands/scheduler.py
+++ b/notifier/management/commands/scheduler.py
@@ -1,0 +1,29 @@
+from apscheduler.scheduler import Scheduler
+from django.conf import settings
+from django.core.management.base import BaseCommand, CommandError
+
+from notifier.tasks import do_forums_digests
+
+# N.B. standalone=True means that sched.start() will block until forcibly stopped.
+sched = Scheduler(standalone=True)
+
+@sched.cron_schedule(**settings.DIGEST_CRON_SCHEDULE)
+def digest_job():
+    do_forums_digests.delay()
+
+class Command(BaseCommand):
+
+    help = """Start the notifier scheduler.  Important environment settings are:
+    
+    BROKER_URL
+        Celery broker URL.  Point this where your celery workers look for tasks.
+    
+    FORUM_DIGEST_TASK_INTERVAL (optional)
+        Number of minutes between digests (int).  Default is 1440.  The value must
+        be a factor of 1440.  If 1440, the forums digest job will fire at midnight
+        daily.
+
+    """
+
+    def handle(self, *args, **options):
+        sched.start()

--- a/notifier/settings.py
+++ b/notifier/settings.py
@@ -3,8 +3,6 @@ import logging
 import os
 import platform
 
-from celery.schedules import crontab
-
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.sqlite3', # Add 'postgresql_psycopg2', 'mysql', 'sqlite3' or 'oracle'.
@@ -167,20 +165,14 @@ if LOG_FILE:
 
 CELERY_TIMEZONE = 'UTC'
 
+# set up schedule for forum digest job
 if FORUM_DIGEST_TASK_INTERVAL==1440:
     # in the production case, make the 24 hour cycle happen at a 
     # predetermined time of day (midnight UTC).
-    digest_schedule = crontab(minute=0, hour=0)
+    DIGEST_CRON_SCHEDULE = {'hour': 0}
 else:
-    # in special (testing) cases, just let celerybeat manage a timedelta.
-    digest_schedule = timedelta(minutes=FORUM_DIGEST_TASK_INTERVAL)
+    DIGEST_CRON_SCHEDULE = {'minute': '*/{}'.format(FORUM_DIGEST_TASK_INTERVAL) }
 
-CELERYBEAT_SCHEDULE = {
-    'send_digests': {
-        'task': 'notifier.tasks.do_forums_digests',
-        'schedule': digest_schedule,
-    },
-}
 DAILY_TASK_MAX_RETRIES = 2
 DAILY_TASK_RETRY_DELAY = 60
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 Django==1.4.5
 amqp==1.0.12
 anyjson==0.3.3
+APScheduler==2.1.1
 autopep8==0.9.2
 billiard==2.7.3.28
 celery==3.0.19


### PR DESCRIPTION
@gwprice @kevinchugh @e0d 

Reimplements identical functionality using APS https://pypi.python.org/pypi/APScheduler.  So far, this has worked in manual tests against the staging environment (whereas celery.beat was failing running under the same conditions).

Deployment-wise, this is envisioned to run under supervisord with the following command (--help works):
    python manage.py scheduler
BROKER_URL must be set properly in order to correctly invoke the celery tasks - most other configuration settings are needed only by the workers and don't apply here.
