### PR TITLE
Config by environment: sqlite DB location, email_use_tls

### DIFF
--- a/notifier/settings.py
+++ b/notifier/settings.py
@@ -55,6 +55,7 @@ EMAIL_HOST = os.getenv('EMAIL_HOST', 'localhost')
 EMAIL_PORT = os.getenv('EMAIL_PORT', 1025)
 EMAIL_HOST_USER = os.getenv('EMAIL_HOST_USER')
 EMAIL_HOST_PASSWORD = os.getenv('EMAIL_HOST_PASSWORD')
+EMAIL_USE_TLS = os.getenv('EMAIL_USE_TLS')
 
 # email settings independent of backend
 EMAIL_DOMAIN = os.getenv('EMAIL_DOMAIN', 'notifications.edx.org')


### PR DESCRIPTION
@jimabramson, can you review and tell me your thoughts?  

Was getting this error on install:

```
TASK: [notifier | syncdb]
*****************************************************

<--snip-->

"/opt/wwc/notifier/virtualenvs/notifier/local/lib/python2.7/site-packages/django/db/backends/sqlite3/base.py",
line 278, in _sqlite_create_connection
    self.connection = Database.connect(**kwargs)
sqlite3.OperationalError: unable to open database file

FATAL: all hosts have already failed -- aborting
```

Added env variable to put in a good place.

Second change was the plumb through the EMAIL_USE_TLS variable, Amazone SES needs this.
