### PR TITLE
Use HTTP header for comments service auth

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,10 @@ These are notable changes in notifier.  This is a rolling list of changes,
 in roughly chronological order, most recent first.  Add your entries at or near
 the top.
 
+**Comments Service Auth**
+Use HTTP header auth instead of URL parameter auth for comments service. This
+requires cs_comments_service commit cf39aab or later.
+
 **Batch Query Size**
 The setting FORUM_DIGEST_TASK_BATCH_SIZE, which sets the maximum number of users
 per query when pulling updates from the comments service, has been reduced from

--- a/notifier/pull.py
+++ b/notifier/pull.py
@@ -97,9 +97,9 @@ def generate_digest_content(user_ids, from_dt, to_dt):
     api_url = settings.CS_URL_BASE + '/api/v1/notifications'
     user_ids = ','.join(map(str, user_ids))
     dt_format = '%Y-%m-%d %H:%M:%S%z'
-    params = {
-        'api_key': settings.CS_API_KEY,
-        }
+    headers = {
+        'X-Edx-Api-Key': settings.CS_API_KEY,
+    }
     data = {
         'user_ids': user_ids,
         'from': from_dt.strftime(dt_format),
@@ -108,7 +108,7 @@ def generate_digest_content(user_ids, from_dt, to_dt):
 
     with dog_stats_api.timer('notifier.comments_service.time'):
         logger.info('calling comments service to pull digests for %d user(s)', len(user_ids))
-        res = _http_post(api_url, params=params, data=data).json
+        res = _http_post(api_url, headers=headers, data=data).json
 
     return Parser.parse(res)
 

--- a/notifier/tests/test_pull.py
+++ b/notifier/tests/test_pull.py
@@ -199,15 +199,15 @@ class PullTestCase(TestCase):
         with patch('requests.post', return_value=Mock(json={})) as p:         
             g = generate_digest_content(["a", "b", "c"], from_dt, to_dt)
             expected_api_url = '*test_cs_url*/api/v1/notifications'
-            expected_params = {
-                'api_key': '*test_cs_key*',
-                }
+            expected_headers = {
+                'X-Edx-Api-Key': '*test_cs_key*',
+            }
             expected_post_data = {
                 'user_ids': 'a,b,c',
                 'from': '2013-01-01 00:00:00', # TODO tz offset
                 'to': '2013-01-02 00:00:00'
             }
-            p.assert_called_once_with(expected_api_url, params=expected_params, data=expected_post_data)            
+            p.assert_called_once_with(expected_api_url, headers=expected_headers, data=expected_post_data)            
             self.assertRaises(StopIteration, g.next)
         
         # single result


### PR DESCRIPTION
Previously, authentication was done using a URL parameter, which would
appear in various logs. Now, authentication is done more appropriately
with an HTTP header. Note that this requires cs_comments_service commit
cf39aabdd160176ebf206ca19d3ee030161a0b47 or later.

@jimabramson 
