### PR TITLE
Parameterize logo url.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,3 +1,4 @@
 Jim Abramson <jsa@edx.org>
 Greg Price <gprice@edx.org>
 Marco Morales <marcotuts@gmail.com>
+David Adams <dcadams@stanford.edu>

--- a/notifier/digest.py
+++ b/notifier/digest.py
@@ -212,7 +212,7 @@ def render_digest(user, digest, title, description):
         'course_count': len(digest.courses),
         'course_names': _make_text_list([course.title for course in digest.courses]),
         'thread_count': sum(course.thread_count for course in digest.courses),
-        'logo_image_url': "{}/static/images/header-logo.png".format(settings.LMS_URL_BASE),
+        'logo_image_url': settings.LOGO_IMAGE_URL,
         'unsubscribe_url': _get_unsubscribe_url(user['username']),
         'postal_address': settings.EMAIL_SENDER_POSTAL_ADDRESS,
         })

--- a/notifier/settings.py
+++ b/notifier/settings.py
@@ -195,3 +195,6 @@ CELERYD_PREFETCH_MULTIPLIER = 1
 LANGUAGE_CODE = os.getenv('NOTIFIER_LANGUAGE', 'en-us')
 USE_L10N = True
 LOCALE_PATHS = (os.path.join(os.path.dirname(os.path.dirname(__file__)), 'locale'),)
+
+# Parameterize digest logo image url
+LOGO_IMAGE_URL = "{}/static/images/header-logo.png".format(LMS_URL_BASE)


### PR DESCRIPTION
Parameterize logo url so we can replace existing digest logo with Stanford logo.
