### PR TITLE
Allow LOGO_IMAGE_URL to be environment variable.

### DIFF
--- a/notifier/settings.py
+++ b/notifier/settings.py
@@ -197,4 +197,4 @@ USE_L10N = True
 LOCALE_PATHS = (os.path.join(os.path.dirname(os.path.dirname(__file__)), 'locale'),)
 
 # Parameterize digest logo image url
-LOGO_IMAGE_URL = "{}/static/images/header-logo.png".format(LMS_URL_BASE)
+LOGO_IMAGE_URL = os.getenv('LOGO_IMAGE_URL', "{}/static/images/header-logo.png".format(LMS_URL_BASE))


### PR DESCRIPTION
Needed for installation purposes.
