### PR TITLE
Update Transifex project name

### DIFF
--- a/.tx/config
+++ b/.tx/config
@@ -1,7 +1,7 @@
 [main]
 host = https://www.transifex.com
 
-[edx-notifier.django]
+[edx-platform.notifier-django]
 file_filter = locale/<lang>/LC_MESSAGES/django.po
 source_file = locale/en_US/LC_MESSAGES/django.po
 source_lang = en_US

--- a/AUTHORS
+++ b/AUTHORS
@@ -2,3 +2,4 @@ Jim Abramson <jsa@edx.org>
 Greg Price <gprice@edx.org>
 Marco Morales <marcotuts@gmail.com>
 David Adams <dcadams@stanford.edu>
+Sarina Canelake <sarina@edx.org>


### PR DESCRIPTION
@gwprice @nedbat This moves the notifier project into edx-platform. 

https://www.transifex.com/projects/p/edx-platform/resource/notifier-django/
