### PR TITLE
surface LMS endpoint errors explicitly.

### DIFF
--- a/notifier/user.py
+++ b/notifier/user.py
@@ -35,8 +35,11 @@ def _http_get(*a, **kw):
     except requests.exceptions.ConnectionError, e:
         _, msg, tb = sys.exc_info()
         raise UserServiceException, "request failed: {}".format(msg), tb
-    if response.status_code == 500:
-        raise UserServiceException, "HTTP Error 500: {}".format(response.reason)
+    if response.status_code != 200:
+        raise UserServiceException, "HTTP Error {}: {}".format(
+            response.status_code,
+            response.reason
+        )
     return response
 
 def get_digest_subscribers():


### PR DESCRIPTION
@e0d @gwprice 
@nasthagiri FYI

The lack of good handling for non-200 responses burned some time today, this should prevent similar issues in the future. 
