### PR TITLE
Language code fix

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -5,4 +5,5 @@ David Adams <dcadams@stanford.edu>
 Sarina Canelake <sarina@edx.org>
 Nimisha Asthagiri <nasthagiri@edx.org>
 Christina Roberts <christina@edx.org>
+Myles Fong <i@myles.hk>
 

--- a/notifier/settings.py
+++ b/notifier/settings.py
@@ -189,13 +189,13 @@ LANGUAGE_CODE = os.getenv('NOTIFIER_LANGUAGE', 'en')
 LANGUAGES = (
     ("en", "English"),
     ("ar", "Arabic"),
-    ("es_419", "Spanish (Latin America)"),
+    ("es-419", "Spanish (Latin America)"),
     ("fr", "French"),
     ("he", "Hebrew"),
     ("hi", "Hindi"),
-    ("pt_BR", "Portuguese (Brazil)"),
+    ("pt-br", "Portuguese (Brazil)"),
     ("ru", "Russian"),
-    ("zh_CN", "Chinese (Simplified)"),
+    ("zh-cn", "Chinese (China)"),
 )
 USE_L10N = True
 LOCALE_PATHS = (os.path.join(os.path.dirname(os.path.dirname(__file__)), 'locale'),)


### PR DESCRIPTION
The language code in `LANGUAGE_CODE` as well as `LANGUAGES` list must match the format that `edx-platform` uses them, e.g. `zh-cn` instead of `zh_CN`. For a complete list of language codes in Dogwood, please refer to https://github.com/edx/edx-platform/blob/named-release/dogwood.rc/lms/envs/common.py#L859