### PR TITLE
Use latest kombu==3.0.x

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ django-coverage==1.2.4
 django-ses==0.7.0
 dogapi==1.11.1
 dogstatsd-python==0.5.6
-kombu==3.0.29
+kombu==3.0.37
 logilab-astng==0.24.3
 logilab-common==1.1.0
 mock==1.0.1


### PR DESCRIPTION
Xenial moves us from Python 2.7.10 to Python 2.7.12, which removed an
internal name that kombu was using. This was fixed in kombu==3.0.30.

https://github.com/celery/kombu/issues/545