### PR TITLE
Make it possible to configure the database via environment variables

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -6,4 +6,4 @@ Sarina Canelake <sarina@edx.org>
 Nimisha Asthagiri <nasthagiri@edx.org>
 Christina Roberts <christina@edx.org>
 Myles Fong <i@myles.hk>
-
+Matjaz Gregoric <matjaz@opencraft.com>

--- a/notifier/settings.py
+++ b/notifier/settings.py
@@ -5,12 +5,17 @@ import platform
 
 DATABASES = {
     'default': {
-        'ENGINE': 'django.db.backends.sqlite3', # Add 'postgresql_psycopg2', 'mysql', 'sqlite3' or 'oracle'.
-        'NAME':  os.path.join(os.getenv('NOTIFIER_DB_DIR', '.'), 'notifier.db'),
-        'USER': '',                      # Not used with sqlite3.
-        'PASSWORD': '',                  # Not used with sqlite3.
-        'HOST': '',                      # Set to empty string for localhost. Not used with sqlite3.
-        'PORT': '',                      # Set to empty string for default. Not used with sqlite3.
+        # Database backend defaults to 'sqlite3', but 'mysql' is also supported.
+        'ENGINE': os.getenv('NOTIFIER_DATABASE_ENGINE', 'django.db.backends.sqlite3'),
+        # Name should be set to database file path when using sqlite, and database name when using mysql.
+        'NAME': os.getenv('NOTIFIER_DATABASE_NAME', os.path.join(os.getenv('NOTIFIER_DB_DIR', '.'), 'notifier.db')),
+        # User and password are not used by sqlite, but you will have to set them when using mysql.
+        'USER': os.getenv('NOTIFIER_DATABASE_USER', ''),
+        'PASSWORD': os.getenv('NOTIFIER_DATABASE_PASSWORD', ''),
+        # Host is not used by sqlite. Empty string means localhost when using mysql.
+        'HOST': os.getenv('NOTIFIER_DATABASE_HOST', ''),
+        # Port is not used by sqlite. Empty string means default port when using mysql.
+        'PORT': os.getenv('NOTIFIER_DATABASE_PORT', ''),
     }
 }
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,6 +15,7 @@ kombu==3.0.37
 logilab-astng==0.24.3
 logilab-common==1.1.0
 mock==1.0.1
+MySQL-python==1.2.5
 pep8==1.6.2
 pylint==1.4.4
 python-dateutil==2.4.2


### PR DESCRIPTION
This patch makes it possible to configure notifier to use an external MySQL database. The database engine still defaults to sqlite3 and the change is backwards compatible.

Motivation: Currently you can not run more than one notifier instance at the same time since each notifier instance works independently, which results in users receiving duplicate digest messages.
We plan to use external MySQL to synchronize multiple notifier instances to make it safe for muliple instances to run concurrently.

**JIRA ticket**: https://openedx.atlassian.net/browse/OSPR-1675

**Discussions**: This was discussed in a Configuration Hangout several months ago.

**Related ansible var changes**: https://github.com/edx/configuration/pull/3695

**Testing Instructions**:

Verify that database settings still default to sqlite:

1. Checkout this branch in your devstack.
2. In your devstack:
  1. `sudo su notifier`
  2. `source notifier_env`
  3. `source virtualenvs/notifier/bin/activate`
  4. `pip install -r src/requirements.txt`
3. Delete the `/edx/app/notifier/db/notifier.db` sqlite database.
4. Go to the `src` folder and run: `python manage.py syncdb`. The command should succeed and the `/edx/app/notifier/db/notifier.db` should be created again (because database configuration still defaults to sqlite).

Verify that you can configure notifier to use MySQL via environment variables:

1. Delete the `/edx/app/notifier/db/notifier.db` sqlite database again.
2. Create a database & user with read/write permissions in your MySQL server.
3. Add these to the `/edx/app/notifier/notifier_env` file (change the values to match your settings):
  ```
  export NOTIFIER_DATABASE_NAME="notifier"
  export NOTIFIER_DATABASE_ENGINE="django.db.backends.mysql"
  export NOTIFIER_DATABASE_USER="notifier"
  export NOTIFIER_DATABASE_PASSWORD="password"
  export NOTIFIER_DATABASE_HOST="127.0.0.1"
  export NOTIFIER_DATABASE_PORT="3306"
  ```
4. Source the `notifier_env` file.
5. Run `python manage.py syncdb` again. This time no `/edx/app/notifier/db/notifier.db` file should be created. Notifier tables should be successfully created in the provided MySQL database instead.

**Author notes and concerns**:

This adds `MySQL-python` as a dependency to `requirements.txt`, even though it's not needed if using default sqlite3 engine. I assume that's fine and it's not worth trying to make it an optional dependency, but please let me know if that's a problem.

**Reviewers**
- [x] @haikuginger
- [ ] edX reviewer[s] TBD