### PR TITLE
Store scheduled forum digest tasks in the database.

### DIFF
--- a/notifier/models.py
+++ b/notifier/models.py
@@ -1,3 +1,28 @@
 """
-django test runner requires a models.py file.  there is nothing to see here.
+Database models for notifier.
 """
+from datetime import datetime, timedelta
+
+from django.db import models
+
+
+class ForumDigestTask(models.Model):
+    """
+    ForumDigestTask model is used for synchronization between notifier schedulers to avoid multiple
+    scheduler instances from scheduling duplicate forum digest tasks.
+    """
+    from_dt = models.DateTimeField(help_text="Beginning of time slice for which to send forum digests.")
+    to_dt = models.DateTimeField(help_text="End of time slice for which to send forum digests.")
+    node = models.CharField(max_length=255, blank=True, help_text="Name of node that scheduled the task.")
+    created = models.DateTimeField(auto_now_add=True, help_text="Time at which the task was scheduled.")
+
+    class Meta:
+        unique_together = (('from_dt', 'to_dt'),)
+
+    @classmethod
+    def prune_old_tasks(cls, day_limit):
+        """
+        Deletes all tasks older than `day_limit` days from the database.
+        """
+        last_keep_dt = datetime.utcnow() - timedelta(days=day_limit)
+        cls.objects.filter(created__lt=last_keep_dt).delete()

--- a/notifier/settings.py
+++ b/notifier/settings.py
@@ -100,6 +100,8 @@ FORUM_DIGEST_TASK_MAX_RETRIES = 2
 FORUM_DIGEST_TASK_RETRY_DELAY = 300
 # set the interval (in minutes) at which the top-level digest task is triggered
 FORUM_DIGEST_TASK_INTERVAL = int(os.getenv('FORUM_DIGEST_TASK_INTERVAL', 1440))
+# number of days to keep forum digest task entries in the database before they are deleted
+FORUM_DIGEST_TASK_GC_DAYS = int(os.getenv('FORUM_DIGEST_TASK_GC_DAYS', 30))
 
 
 LOGGING = {


### PR DESCRIPTION
Store scheduled forums digest jobs in the database to avoid scheduling the same digest job twice.

Before the cron-style scheduler schedules a new forums digests job, it checks whether a job with the same parameters had already been scheduled. If it was already scheduled, it returns without doing anything.

Running a forums digest job manually using the `﻿python manage.py forums_digest` management command uses a different code path than the periodic scheduler and bypasses the database check.

**JIRA ticket**: https://openedx.atlassian.net/browse/OSPR-1678

**Discussions**: This was discussed in a Configuration Hangout several months ago.

**Related**: https://github.com/edx/notifier/pull/42

**Testing instructions**:

To properly test this, you should spawn instances of notifier, configured to use a shared MySQL database. You will probably want to set `NOTIFIER_DIGEST_TASK_INTERVAL` to something low (such as 1 minute) to make this easier to test. Then:

1. Go to the discussion page of an arbitrary course in the LMS and make sure you are subscribed to digest emails.
2. Make a new forum post and wait up to a minute for the notifier service to send out digests.
3. Observe that you only received a single copy of the digest email.

**Sandbox**:

A sandbox combining this PR and https://github.com/edx/configuration/pull/3695 has been set up at 
https://notifier-mysql-db.stage.opencraft.hosting. The instance consists of two app servers. The notifier service is running on both.

**Reviewers**
- [x] @haikuginger
- [x] edX reviewer: @yro 