### PR TITLE
Upgrade Django version to 1.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,6 @@ install:
   - pip install -r requirements.txt
   - pip install coveralls
 script:
-  - python manage.py test notifier
+  - sudo rm -f /etc/boto.cfg && python manage.py test notifier
 after_success:
   - coveralls

--- a/notifier/management/commands/forums_digest.py
+++ b/notifier/management/commands/forums_digest.py
@@ -42,7 +42,7 @@ class Command(BaseCommand):
                     action='store',
                     dest='to_datetime',
                     default=None,
-                    help='datetime as of which to generate digest content, in ISO-8601 format (UTC).  Defaults to today at midnight (UTC).'),
+                    help='datetime as of which to generate digest content, in ISO-8601 format (UTC).  Defaults to today at 00:00 (UTC).'),
         make_option('--minutes',
                     action='store',
                     dest='minutes',

--- a/notifier/settings.py
+++ b/notifier/settings.py
@@ -211,3 +211,5 @@ LOCALE_PATHS = (os.path.join(os.path.dirname(os.path.dirname(__file__)), 'locale
 LOGO_IMAGE_URL = os.getenv('LOGO_IMAGE_URL', "{}/static/images/edx-theme/edx-logo-77x36.png".format(LMS_URL_BASE))
 
 DEAD_MANS_SNITCH_URL = os.getenv('DEAD_MANS_SNITCH_URL', '')
+
+SECRET_KEY = os.getenv('SECRET_KEY', 'secret_key')

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,14 +1,15 @@
-Django==1.4.22
+Django==1.8
 amqp==1.4.7
 APScheduler==3.0.4
 autopep8==1.2.1
 billiard==3.3.0.21
+boto==2.48
 celery==3.1.19
 coverage==4.0.1
 django-celery==3.1.17
 django-configurations==0.8
 django-coverage==1.2.4
-django-ses==0.7.0
+django-ses==0.8.3.1
 dogapi==1.11.1
 dogstatsd-python==0.5.6
 kombu==3.0.37


### PR DESCRIPTION
Upgrading Django version to 1.8. 
Explicitly upgrading django-ses and boto.
Workaround for boto and travis issue that I think might have caused the notifier to stop working, see [this](https://github.com/travis-ci/travis-ci/issues/7940) issue.