### PR TITLE
Django==1.8.18, jam the language_code into settings.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 notifier.db
 *.DS_Store
 notifier.log
+venvs

--- a/notifier/management/commands/forums_digest.py
+++ b/notifier/management/commands/forums_digest.py
@@ -163,7 +163,9 @@ class Command(BaseCommand):
             generate_and_send_digests.delay(
                 some_users,
                 from_datetime,
-                to_datetime)
+                to_datetime,
+                language=settings.LANGUAGE_CODE
+            )
 
         user_batch = []
         for user in users:

--- a/notifier/tasks.py
+++ b/notifier/tasks.py
@@ -22,7 +22,7 @@ logger = logging.getLogger(__name__)
 
 
 @celery.task(rate_limit=settings.FORUM_DIGEST_TASK_RATE_LIMIT, max_retries=settings.FORUM_DIGEST_TASK_MAX_RETRIES)
-def generate_and_send_digests(users, from_dt, to_dt):
+def generate_and_send_digests(users, from_dt, to_dt, language=None):
     """
     This task generates and sends forum digest emails to multiple users in a
     single background operation.
@@ -33,6 +33,7 @@ def generate_and_send_digests(users, from_dt, to_dt):
     `from_dt` and `to_dt` are datetime objects representing the start and end
     of the time window for which to generate a digest.
     """
+    settings.LANGUAGE_CODE = language or settings.LANGUAGE_CODE
     users_by_id = dict((str(u['id']), u) for u in users)
     msgs = []
     try:
@@ -150,6 +151,6 @@ def do_forums_digests(self):
 
     try:
         for user_batch in batch_digest_subscribers():
-            generate_and_send_digests.delay(user_batch, from_dt, to_dt)
+            generate_and_send_digests.delay(user_batch, from_dt, to_dt, language=settings.LANGUAGE_CODE)
     except UserServiceException, e:
         raise do_forums_digests.retry(exc=e)

--- a/notifier/tests/test_tasks.py
+++ b/notifier/tests/test_tasks.py
@@ -184,7 +184,7 @@ class TasksTestCase(TestCase):
             task_result = do_forums_digests.delay()
             self.assertTrue(task_result.successful())
             self.assertEqual(t.delay.call_count, 2)
-            t.delay.assert_called_with([usern(10)], dt1, dt2)
+            t.delay.assert_called_with([usern(10)], dt1, dt2, language=settings.LANGUAGE_CODE)
 
 
     @override_settings(FORUM_DIGEST_TASK_BATCH_SIZE=10)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Django==1.8
+Django==1.8.18
 amqp==1.4.7
 APScheduler==3.0.4
 autopep8==1.2.1


### PR DESCRIPTION
Somehow, `settings.LANGUAGE_CODE` was empty inside the context of the celery task `generate_and_send_digests`.  This jams it in there.  Also upgrades to the latest django 1.8.