### PR TITLE
EDUCATOR-2359 | Add celery config to restart worker after 100 tasks.

### DIFF
--- a/notifier/settings.py
+++ b/notifier/settings.py
@@ -192,6 +192,10 @@ BROKER_HEARTBEAT_CHECKRATE = 2
 # Each worker should only fetch one message at a time
 CELERYD_PREFETCH_MULTIPLIER = 1
 
+# Maximum number of tasks a pool worker process can execute
+# before it's replaced with a new one.
+CELERYD_MAX_TASKS_PER_CHILD = 100
+
 LANGUAGE_CODE = os.getenv('NOTIFIER_LANGUAGE', 'en')
 LANGUAGES = (
     ("en", "English"),


### PR DESCRIPTION
We think there's a memory leak in celery 3.x when using redis as the broker.  See: https://github.com/celery/celery/issues/3436 This PR addresses that issue by having celery workers restart after 100 tasks.