### PR TITLE
Old style exceptions --> new style for Python 3

### DIFF
--- a/notifier/connection_wrapper.py
+++ b/notifier/connection_wrapper.py
@@ -43,7 +43,7 @@ class BackendWrapper(object):
         # never raise Exceptions on close().
         try:
             self._backend.close()
-        except Exception, e:
+        except Exception as e:
             logger.debug("self._backend.close() failed: %s", e)
 
     def __getattr__(self, a):

--- a/notifier/digest.py
+++ b/notifier/digest.py
@@ -60,7 +60,7 @@ def _trunc(s, length):
     # truncate, taking an extra -3 off the orig string for the ellipsis itself
     # see above comment about non-BMP support for why this is done in such
     # elaborate fashion.
-    uchr = lambda x: '\U{0:08x}'.format(x).decode('unicode-escape')
+    uchr = lambda x: r'\U{0:08x}'.format(x).decode('unicode-escape')
     return ''.join(uchr(p) for p in pts[:length - 3]).rsplit(' ', 1)[0].strip() + '...'
 
 

--- a/notifier/management/commands/forums_digest.py
+++ b/notifier/management/commands/forums_digest.py
@@ -103,7 +103,7 @@ class Command(BaseCommand):
             logger.warning('could not show rendered %s: %s', fmt, msg)
 
         try:
-            user_id, digest = generate_digest_content(users_by_id, from_dt, to_dt).next()
+            user_id, digest = next(generate_digest_content(users_by_id, from_dt, to_dt))
         except StopIteration:
             _fail('no digests found')
             return

--- a/notifier/pull.py
+++ b/notifier/pull.py
@@ -29,7 +29,7 @@ def _http_post(*a, **kw):
         response = requests.post(*a, **kw)
     except requests.exceptions.ConnectionError as e:
         _, msg, tb = sys.exc_info()
-        raise CommentsServiceException("comments service request failed: {}".format(msg), tb)
+        raise CommentsServiceException, "comments service request failed: {}".format(msg), tb
     if response.status_code != 200:
         raise CommentsServiceException("comments service HTTP Error {code}: {reason}".format(code=response.status_code, reason=response.reason))
     return response

--- a/notifier/pull.py
+++ b/notifier/pull.py
@@ -27,7 +27,7 @@ def _http_post(*a, **kw):
     try:
         logger.debug('POST %s %s', a[0], kw)
         response = requests.post(*a, **kw)
-    except requests.exceptions.ConnectionError, e:
+    except requests.exceptions.ConnectionError as e:
         _, msg, tb = sys.exc_info()
         raise CommentsServiceException, "comments service request failed: {}".format(msg), tb
     if response.status_code != 200:

--- a/notifier/pull.py
+++ b/notifier/pull.py
@@ -29,9 +29,9 @@ def _http_post(*a, **kw):
         response = requests.post(*a, **kw)
     except requests.exceptions.ConnectionError as e:
         _, msg, tb = sys.exc_info()
-        raise CommentsServiceException, "comments service request failed: {}".format(msg), tb
+        raise CommentsServiceException("comments service request failed: {}".format(msg), tb)
     if response.status_code != 200:
-        raise CommentsServiceException, "comments service HTTP Error {code}: {reason}".format(code=response.status_code, reason=response.reason)
+        raise CommentsServiceException("comments service HTTP Error {code}: {reason}".format(code=response.status_code, reason=response.reason))
     return response
 
 

--- a/notifier/tasks.py
+++ b/notifier/tasks.py
@@ -155,5 +155,5 @@ def do_forums_digests(self):
     try:
         for user_batch in batch_digest_subscribers():
             generate_and_send_digests.delay(user_batch, from_dt, to_dt, language=settings.LANGUAGE_CODE)
-    except UserServiceException, e:
+    except UserServiceException as e:
         raise do_forums_digests.retry(exc=e)

--- a/notifier/tests/test_tasks.py
+++ b/notifier/tests/test_tasks.py
@@ -111,7 +111,7 @@ class TasksTestCase(TestCase):
         ):
             # execute task
             task_result = generate_and_send_digests.delay(
-                (usern(n) for n in xrange(2, 11)), datetime.datetime.now(), datetime.datetime.now())
+                (usern(n) for n in range(2, 11)), datetime.datetime.now(), datetime.datetime.now())
             self.assertTrue(task_result.successful())
 
             # all messages were sent
@@ -142,7 +142,7 @@ class TasksTestCase(TestCase):
                 # give up
                 try:
                     generate_and_send_digests.delay(
-                        [usern(n) for n in xrange(2, 11)], datetime.datetime.now(), datetime.datetime.now())
+                        [usern(n) for n in range(2, 11)], datetime.datetime.now(), datetime.datetime.now())
                 except SESMaxSendingRateExceededError as e:
                     self.assertEqual(
                         mock_backend.send_messages.call_count,
@@ -163,7 +163,7 @@ class TasksTestCase(TestCase):
             expected_num_tries = 1 + settings.FORUM_DIGEST_TASK_MAX_RETRIES
             try:
                 generate_and_send_digests.delay(
-                    [usern(n) for n in xrange(2, 11)], datetime.datetime.now(), datetime.datetime.now())
+                    [usern(n) for n in range(2, 11)], datetime.datetime.now(), datetime.datetime.now())
             except CommentsServiceException as e:
                 self.assertEqual(mock_cs_call.call_count, expected_num_tries)
             else:
@@ -177,7 +177,7 @@ class TasksTestCase(TestCase):
         dt1 = datetime.datetime.utcnow()
         dt2 = dt1 + datetime.timedelta(days=1)
         with nested(
-            patch('notifier.tasks.get_digest_subscribers', return_value=(usern(n) for n in xrange(11))),
+            patch('notifier.tasks.get_digest_subscribers', return_value=(usern(n) for n in range(11))),
             patch('notifier.tasks.generate_and_send_digests'),
             patch('notifier.tasks._time_slice', return_value=(dt1, dt2))
         ) as (p, t, ts):
@@ -214,7 +214,7 @@ class TasksTestCase(TestCase):
         dt1 = datetime.datetime.utcnow()
         dt2 = dt1 + datetime.timedelta(days=1)
         with nested(
-            patch('notifier.tasks.get_digest_subscribers', return_value=(usern(n) for n in xrange(11))),
+            patch('notifier.tasks.get_digest_subscribers', return_value=(usern(n) for n in range(11))),
             patch('notifier.tasks.generate_and_send_digests'),
             patch('notifier.tasks._time_slice', return_value=(dt1, dt2))
         ) as (p, t, ts):
@@ -237,7 +237,7 @@ class TasksTestCase(TestCase):
         dt3 = dt2 + datetime.timedelta(days=1)
         # Scheduling the task for the first time sends the digests:
         with nested(
-            patch('notifier.tasks.get_digest_subscribers', return_value=(usern(n) for n in xrange(10))),
+            patch('notifier.tasks.get_digest_subscribers', return_value=(usern(n) for n in range(10))),
             patch('notifier.tasks._time_slice', return_value=(dt1, dt2)),
             patch('notifier.tasks.generate_and_send_digests')
         ) as (_gs, _ts, t):
@@ -246,7 +246,7 @@ class TasksTestCase(TestCase):
             self.assertEqual(t.delay.call_count, 1)
         # Scheduling the task with the same time slice again does nothing:
         with nested(
-            patch('notifier.tasks.get_digest_subscribers', return_value=(usern(n) for n in xrange(10))),
+            patch('notifier.tasks.get_digest_subscribers', return_value=(usern(n) for n in range(10))),
             patch('notifier.tasks._time_slice', return_value=(dt1, dt2)),
             patch('notifier.tasks.generate_and_send_digests')
         ) as (_gs, _ts, t):
@@ -255,7 +255,7 @@ class TasksTestCase(TestCase):
             self.assertEqual(t.delay.call_count, 0)
         # Scheduling the task with a different time slice sends the digests:
         with nested(
-            patch('notifier.tasks.get_digest_subscribers', return_value=(usern(n) for n in xrange(10))),
+            patch('notifier.tasks.get_digest_subscribers', return_value=(usern(n) for n in range(10))),
             patch('notifier.tasks._time_slice', return_value=(dt2, dt3)),
             patch('notifier.tasks.generate_and_send_digests')
         ) as (_gs, _ts, t):
@@ -276,7 +276,7 @@ class TasksTestCase(TestCase):
             # Bypass field's auto_now_add by forcing the update via query manager.
             ForumDigestTask.objects.filter(pk=task.pk).update(created=dt)
         with nested(
-            patch('notifier.tasks.get_digest_subscribers', return_value=(usern(n) for n in xrange(11))),
+            patch('notifier.tasks.get_digest_subscribers', return_value=(usern(n) for n in range(11))),
             patch('notifier.tasks.generate_and_send_digests'),
         ) as (p, t):
             # Two of the tasks that we created above are older than 5 days.

--- a/notifier/tests/test_tasks.py
+++ b/notifier/tests/test_tasks.py
@@ -80,7 +80,7 @@ class TasksTestCase(TestCase):
         data = json.load(
             open(join(dirname(__file__), 'cs_notifications.result.json')))
 
-        user_id, digest = self._process_cs_response_with_user_info(data).next()
+        user_id, digest = next(self._process_cs_response_with_user_info(data))
         user = usern(10)
         with patch('notifier.tasks.generate_digest_content', return_value=[(user_id, digest)]) as p:
 

--- a/notifier/tests/test_user.py
+++ b/notifier/tests/test_user.py
@@ -109,13 +109,13 @@ class UserTestCase(TestCase):
         with patch('requests.get', return_value=mock_response) as p:
             res = []
             g = get_digest_subscribers()
-            res.append(g.next())
+            res.append(next(g))
             p.assert_called_once_with(
                 self.expected_api_url,
                 params=self.expected_params,
                 headers=self.expected_headers)
-            res.append(g.next())
-            res.append(g.next()) # result 3, end of page
+            res.append(next(g))
+            res.append(next(g)) # result 3, end of page
             self.assertEqual([
                 mkexpected(mkresult(1)),
                 mkexpected(mkresult(2)),
@@ -126,12 +126,12 @@ class UserTestCase(TestCase):
         mock_response = make_mock_json_response(json=expected_multi_p2)
         with patch('requests.get', return_value=mock_response) as p:
             self.expected_params['page']=2
-            self.assertEqual(mkexpected(mkresult(4)), g.next())
+            self.assertEqual(mkexpected(mkresult(4)), next(g))
             p.assert_called_once_with(
                 self.expected_api_url,
                 params=self.expected_params,
                 headers=self.expected_headers)
-            self.assertEqual(mkexpected(mkresult(5)), g.next())
+            self.assertEqual(mkexpected(mkresult(5)), next(g))
             self.assertEqual(1, p.call_count)
             self.assertRaises(StopIteration, g.next)
 

--- a/notifier/user.py
+++ b/notifier/user.py
@@ -33,7 +33,7 @@ def _http_get(*a, **kw):
         response = requests.get(*a, **kw)
     except requests.exceptions.ConnectionError as e:
         _, msg, tb = sys.exc_info()
-        raise UserServiceException("request failed: {}".format(msg), tb)
+        raise UserServiceException, "request failed: {}".format(msg), tb
     if response.status_code != 200:
         raise UserServiceException("HTTP Error {}: {}".format(
             response.status_code,

--- a/notifier/user.py
+++ b/notifier/user.py
@@ -33,12 +33,12 @@ def _http_get(*a, **kw):
         response = requests.get(*a, **kw)
     except requests.exceptions.ConnectionError as e:
         _, msg, tb = sys.exc_info()
-        raise UserServiceException, "request failed: {}".format(msg), tb
+        raise UserServiceException("request failed: {}".format(msg), tb)
     if response.status_code != 200:
-        raise UserServiceException, "HTTP Error {}: {}".format(
+        raise UserServiceException("HTTP Error {}: {}".format(
             response.status_code,
             response.reason
-        )
+        ))
     return response
 
 def get_digest_subscribers():

--- a/notifier/user.py
+++ b/notifier/user.py
@@ -31,7 +31,7 @@ def _http_get(*a, **kw):
     try:
         logger.debug('GET {} {}'.format(a[0], kw))
         response = requests.get(*a, **kw)
-    except requests.exceptions.ConnectionError, e:
+    except requests.exceptions.ConnectionError as e:
         _, msg, tb = sys.exc_info()
         raise UserServiceException, "request failed: {}".format(msg), tb
     if response.status_code != 200:


### PR DESCRIPTION
Old style exceptions are syntax errors in Python 3 but new style exceptions work as expected in both Python 2 and Python 3.