### PR TITLE
Travis CI: Add Python 3.7 to testing in allow_failures mode

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,12 @@
 language: python
 python:
   - "2.7"
+matrix:
+  allow_failures:
+    - python: "3.7"
+  include:
+    - python: "3.7"
+      dist: xenial  # required for Python >= 3.7 (travis-ci/travis-ci#9069)
 branches:
   only:
     - master

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,11 @@
 language: python
 matrix:
   allow_failures:
+    - python: "3.6"
     - python: "3.7"
   include:
     - python: "2.7"
+    - python: "3.6"
     - python: "3.7"
       dist: xenial  # required for Python >= 3.7 (travis-ci/travis-ci#9069)
 branches:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,9 @@
 language: python
-python:
-  - "2.7"
 matrix:
   allow_failures:
     - python: "3.7"
   include:
+    - python: "2.7"
     - python: "3.7"
       dist: xenial  # required for Python >= 3.7 (travis-ci/travis-ci#9069)
 branches:

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,8 @@ kombu==3.0.37
 logilab-astng==0.24.3
 logilab-common==1.1.0
 mock==1.0.1
-MySQL-python==1.2.5
+MySQL-python==1.2.5; python_version < '3.0'
+mysqlclient==1.4.2.post1; python_version >= '3.0'
 pep8==1.6.2
 pylint==1.4.4
 python-dateutil==2.4.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,6 +23,5 @@ pytz==2015.7
 requests==2.8.1
 six==1.10.0
 transifex-client
-wsgiref==0.1.2
 -e git+https://github.com/edx/opaque-keys.git@0.1.2#egg=opaque-keys
 redis==2.10.6


### PR DESCRIPTION
Helps us understand were we are on Python 3 compatibility.