### PR TITLE
BOM-2023 : Use django-ses with boto3

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -9,33 +9,38 @@ amqp==1.4.9               # via -r requirements/base.in, kombu
 anyjson==0.3.3            # via kombu
 apscheduler==3.6.3        # via -r requirements/base.in
 billiard==3.3.0.23        # via -r requirements/base.in, celery
-boto==2.49.0              # via -r requirements/base.in, django-ses
+boto3==1.14.62            # via django-ses
+boto==2.49.0              # via -r requirements/base.in
+botocore==1.17.62         # via boto3, s3transfer
 celery==3.1.26.post2      # via -r requirements/base.in, django-celery
 certifi==2020.6.20        # via requests
 chardet==3.0.4            # via requests
 django-celery==3.3.1      # via -r requirements/base.in
 django-configurations==2.2  # via -r requirements/base.in
 django-coverage==1.2.4    # via -r requirements/base.in
-django-ses==0.8.14        # via -r requirements/base.in
-django==1.11.29           # via -c requirements/constraints.txt, -r requirements/base.in, django-celery
+django-ses==1.0.3         # via -r requirements/base.in
+django==1.11.29           # via -c requirements/constraints.txt, -r requirements/base.in, django-celery, django-ses
+docutils==0.15.2          # via botocore
 funcsigs==1.0.2           # via apscheduler
 future==0.18.2            # via django-ses
-futures==3.3.0 ; python_version == "2.7"  # via -c requirements/constraints.txt, apscheduler
+futures==3.3.0 ; python_version == "2.7"  # via -c requirements/constraints.txt, apscheduler, s3transfer
 idna==2.10                # via requests
+jmespath==0.10.0          # via boto3, botocore
 kombu==3.0.37             # via -r requirements/base.in, celery
 logilab-astng==0.24.3     # via -r requirements/base.in
 logilab-common==1.4.4     # via -r requirements/base.in, logilab-astng
 mysqlclient==1.4.6        # via -r requirements/base.in
-pbr==5.4.5                # via stevedore
-pymongo==3.10.1           # via edx-opaque-keys
-python-dateutil==2.8.1    # via -r requirements/base.in
+pbr==5.5.0                # via stevedore
+pymongo==3.11.0           # via edx-opaque-keys
+python-dateutil==2.8.1    # via -r requirements/base.in, botocore
 pytz==2020.1              # via -r requirements/base.in, apscheduler, celery, django, django-ses, tzlocal
 redis==3.5.3              # via -r requirements/base.in
 requests==2.24.0          # via -r requirements/base.in
+s3transfer==0.3.3         # via boto3
 six==1.15.0               # via -r requirements/base.in, apscheduler, django-configurations, edx-opaque-keys, logilab-common, python-dateutil, stevedore
 stevedore==1.32.0         # via edx-opaque-keys
 tzlocal==2.1              # via apscheduler
-urllib3==1.25.9           # via requests
+urllib3==1.25.10          # via botocore, requests
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -8,35 +8,40 @@
 amqp==1.4.9               # via -r requirements/base.txt, kombu
 anyjson==0.3.3            # via -r requirements/base.txt, kombu
 apscheduler==3.6.3        # via -r requirements/base.txt
-autopep8==1.5.3           # via -r requirements/dev.in
+autopep8==1.5.4           # via -r requirements/dev.in
 billiard==3.3.0.23        # via -r requirements/base.txt, celery
-boto==2.49.0              # via -r requirements/base.txt, django-ses
+boto3==1.14.62            # via -r requirements/base.txt, django-ses
+boto==2.49.0              # via -r requirements/base.txt
+botocore==1.17.62         # via -r requirements/base.txt, boto3, s3transfer
 celery==3.1.26.post2      # via -r requirements/base.txt, django-celery
 certifi==2020.6.20        # via -r requirements/base.txt, requests
 chardet==3.0.4            # via -r requirements/base.txt, requests
 django-celery==3.3.1      # via -r requirements/base.txt
 django-configurations==2.2  # via -r requirements/base.txt
 django-coverage==1.2.4    # via -r requirements/base.txt
-django-ses==0.8.14        # via -r requirements/base.txt
-django==1.11.29           # via -c requirements/constraints.txt, -r requirements/base.txt, django-celery
+django-ses==1.0.3         # via -r requirements/base.txt
+django==1.11.29           # via -c requirements/constraints.txt, -r requirements/base.txt, django-celery, django-ses
+docutils==0.15.2          # via -r requirements/base.txt, botocore
 funcsigs==1.0.2           # via -r requirements/base.txt, apscheduler
 future==0.18.2            # via -r requirements/base.txt, django-ses
-futures==3.3.0 ; python_version == "2.7"  # via -c requirements/constraints.txt, -r requirements/base.txt, apscheduler
+futures==3.3.0 ; python_version == "2.7"  # via -c requirements/constraints.txt, -r requirements/base.txt, apscheduler, s3transfer
 gitdb2==2.0.6             # via gitpython
 gitpython==2.1.15         # via transifex-client
 idna==2.10                # via -r requirements/base.txt, requests
+jmespath==0.10.0          # via -r requirements/base.txt, boto3, botocore
 kombu==3.0.37             # via -r requirements/base.txt, celery
 logilab-astng==0.24.3     # via -r requirements/base.txt
 logilab-common==1.4.4     # via -r requirements/base.txt, logilab-astng
 mysqlclient==1.4.6        # via -r requirements/base.txt
-pbr==5.4.5                # via -r requirements/base.txt, stevedore
+pbr==5.5.0                # via -r requirements/base.txt, stevedore
 pycodestyle==2.6.0        # via autopep8
-pymongo==3.10.1           # via -r requirements/base.txt, edx-opaque-keys
-python-dateutil==2.8.1    # via -r requirements/base.txt
+pymongo==3.11.0           # via -r requirements/base.txt, edx-opaque-keys
+python-dateutil==2.8.1    # via -r requirements/base.txt, botocore
 python-slugify==4.0.1     # via transifex-client
 pytz==2020.1              # via -r requirements/base.txt, apscheduler, celery, django, django-ses, tzlocal
 redis==3.5.3              # via -r requirements/base.txt
 requests==2.24.0          # via -r requirements/base.txt, transifex-client
+s3transfer==0.3.3         # via -r requirements/base.txt, boto3
 six==1.15.0               # via -r requirements/base.txt, apscheduler, django-configurations, edx-opaque-keys, logilab-common, python-dateutil, stevedore, transifex-client
 smmap2==3.0.1             # via gitdb2
 smmap==3.0.4              # via smmap2
@@ -45,7 +50,7 @@ text-unidecode==1.3       # via python-slugify
 toml==0.10.1              # via autopep8
 transifex-client==0.13.11  # via -r requirements/dev.in
 tzlocal==2.1              # via -r requirements/base.txt, apscheduler
-urllib3==1.25.9           # via -r requirements/base.txt, requests, transifex-client
+urllib3==1.25.10          # via -r requirements/base.txt, botocore, requests, transifex-client
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/requirements/django.txt
+++ b/requirements/django.txt
@@ -1,1 +1,1 @@
-django==1.11.29           # via -c requirements/constraints.txt, -r requirements/base.in, -r requirements/base.txt, django-celery
+django==1.11.29           # via -c requirements/constraints.txt, -r requirements/base.in, -r requirements/base.txt, django-celery, django-ses

--- a/requirements/pip_tools.txt
+++ b/requirements/pip_tools.txt
@@ -5,7 +5,7 @@
 #    make upgrade
 #
 click==7.1.2              # via pip-tools
-pip-tools==5.2.1          # via -r requirements/pip_tools.in
+pip-tools==5.3.1          # via -r requirements/pip_tools.in
 six==1.15.0               # via pip-tools
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -19,7 +19,7 @@ enum34==1.1.10            # via astroid
 futures==3.3.0 ; python_version == "2.7"  # via -c requirements/constraints.txt, caniusepython3, isort
 idna==2.10                # via requests
 isort==4.3.21             # via -r requirements/quality.in, pylint
-lazy-object-proxy==1.5.0  # via astroid
+lazy-object-proxy==1.5.1  # via astroid
 mccabe==0.6.1             # via pylint
 packaging==20.4           # via caniusepython3
 pycodestyle==2.6.0        # via -r requirements/quality.in
@@ -33,7 +33,7 @@ requests==2.24.0          # via caniusepython3
 singledispatch==3.4.0.3   # via astroid, pylint
 six==1.15.0               # via astroid, edx-lint, packaging, pydocstyle, pylint, singledispatch
 snowballstemmer==2.0.0    # via pydocstyle
-urllib3==1.25.9           # via requests
+urllib3==1.25.10          # via requests
 wrapt==1.12.1             # via astroid
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -9,33 +9,38 @@ amqp==1.4.9               # via -r requirements/base.in, -r requirements/base.tx
 anyjson==0.3.3            # via -r requirements/base.txt, kombu
 apscheduler==3.6.3        # via -r requirements/base.in, -r requirements/base.txt
 billiard==3.3.0.23        # via -r requirements/base.in, -r requirements/base.txt, celery
-boto==2.49.0              # via -r requirements/base.in, -r requirements/base.txt, django-ses
+boto3==1.14.62            # via -r requirements/base.txt, django-ses
+boto==2.49.0              # via -r requirements/base.in, -r requirements/base.txt
+botocore==1.17.62         # via -r requirements/base.txt, boto3, s3transfer
 celery==3.1.26.post2      # via -r requirements/base.in, -r requirements/base.txt, django-celery
 certifi==2020.6.20        # via -r requirements/base.txt, requests
 chardet==3.0.4            # via -r requirements/base.txt, requests
 django-celery==3.3.1      # via -r requirements/base.in, -r requirements/base.txt
 django-configurations==2.2  # via -r requirements/base.in, -r requirements/base.txt
 django-coverage==1.2.4    # via -r requirements/base.in, -r requirements/base.txt
-django-ses==0.8.14        # via -r requirements/base.in, -r requirements/base.txt
+django-ses==1.0.3         # via -r requirements/base.in, -r requirements/base.txt
+docutils==0.15.2          # via -r requirements/base.txt, botocore
 funcsigs==1.0.2           # via -r requirements/base.txt, apscheduler, mock
 future==0.18.2            # via -r requirements/base.txt, django-ses
-futures==3.3.0 ; python_version == "2.7"  # via -c requirements/constraints.txt, -r requirements/base.txt, apscheduler
+futures==3.3.0 ; python_version == "2.7"  # via -c requirements/constraints.txt, -r requirements/base.txt, apscheduler, s3transfer
 idna==2.10                # via -r requirements/base.txt, requests
+jmespath==0.10.0          # via -r requirements/base.txt, boto3, botocore
 kombu==3.0.37             # via -r requirements/base.in, -r requirements/base.txt, celery
 logilab-astng==0.24.3     # via -r requirements/base.in, -r requirements/base.txt
 logilab-common==1.4.4     # via -r requirements/base.in, -r requirements/base.txt, logilab-astng
 mock==3.0.5               # via -c requirements/constraints.txt, -r requirements/test.in
 mysqlclient==1.4.6        # via -r requirements/base.in, -r requirements/base.txt
-pbr==5.4.5                # via -r requirements/base.txt, stevedore
-pymongo==3.10.1           # via -r requirements/base.txt, edx-opaque-keys
-python-dateutil==2.8.1    # via -r requirements/base.in, -r requirements/base.txt
+pbr==5.5.0                # via -r requirements/base.txt, stevedore
+pymongo==3.11.0           # via -r requirements/base.txt, edx-opaque-keys
+python-dateutil==2.8.1    # via -r requirements/base.in, -r requirements/base.txt, botocore
 pytz==2020.1              # via -r requirements/base.in, -r requirements/base.txt, apscheduler, celery, django, django-ses, tzlocal
 redis==3.5.3              # via -r requirements/base.in, -r requirements/base.txt
 requests==2.24.0          # via -r requirements/base.in, -r requirements/base.txt
+s3transfer==0.3.3         # via -r requirements/base.txt, boto3
 six==1.15.0               # via -r requirements/base.in, -r requirements/base.txt, apscheduler, django-configurations, edx-opaque-keys, logilab-common, mock, python-dateutil, stevedore
 stevedore==1.32.0         # via -r requirements/base.txt, edx-opaque-keys
 tzlocal==2.1              # via -r requirements/base.txt, apscheduler
-urllib3==1.25.9           # via -r requirements/base.txt, requests
+urllib3==1.25.10          # via -r requirements/base.txt, botocore, requests
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/requirements/travis.txt
+++ b/requirements/travis.txt
@@ -9,43 +9,48 @@ amqp==1.4.9               # via -r requirements/test.txt, kombu
 anyjson==0.3.3            # via -r requirements/test.txt, kombu
 apscheduler==3.6.3        # via -r requirements/test.txt
 billiard==3.3.0.23        # via -r requirements/test.txt, celery
-boto==2.49.0              # via -r requirements/test.txt, django-ses
+boto3==1.14.62            # via -r requirements/test.txt, django-ses
+boto==2.49.0              # via -r requirements/test.txt
+botocore==1.17.62         # via -r requirements/test.txt, boto3, s3transfer
 celery==3.1.26.post2      # via -r requirements/test.txt, django-celery
 certifi==2020.6.20        # via -r requirements/test.txt, requests, urllib3
-cffi==1.14.0              # via cryptography
+cffi==1.14.2              # via cryptography
 chardet==3.0.4            # via -r requirements/test.txt, requests
-coverage==5.2             # via coveralls
+coverage==5.3             # via coveralls
 coveralls==1.11.1         # via -r requirements/travis.in
-cryptography==2.9.2       # via pyopenssl, urllib3
+cryptography==3.1         # via pyopenssl, urllib3
 django-celery==3.3.1      # via -r requirements/test.txt
 django-configurations==2.2  # via -r requirements/test.txt
 django-coverage==1.2.4    # via -r requirements/test.txt
-django-ses==0.8.14        # via -r requirements/test.txt
-django==1.11.29           # via -c requirements/constraints.txt, -r requirements/test.txt, django-celery
+django-ses==1.0.3         # via -r requirements/test.txt
+django==1.11.29           # via -c requirements/constraints.txt, -r requirements/test.txt, django-celery, django-ses
 docopt==0.6.2             # via coveralls
+docutils==0.15.2          # via -r requirements/test.txt, botocore
 enum34==1.1.10            # via cryptography
 funcsigs==1.0.2           # via -r requirements/test.txt, apscheduler, mock
 future==0.18.2            # via -r requirements/test.txt, django-ses
-futures==3.3.0 ; python_version == "2.7"  # via -c requirements/constraints.txt, -r requirements/test.txt, apscheduler
+futures==3.3.0 ; python_version == "2.7"  # via -c requirements/constraints.txt, -r requirements/test.txt, apscheduler, s3transfer
 idna==2.10                # via -r requirements/test.txt, requests, urllib3
 ipaddress==1.0.23         # via cryptography, urllib3
+jmespath==0.10.0          # via -r requirements/test.txt, boto3, botocore
 kombu==3.0.37             # via -r requirements/test.txt, celery
 logilab-astng==0.24.3     # via -r requirements/test.txt
 logilab-common==1.4.4     # via -r requirements/test.txt, logilab-astng
 mock==3.0.5               # via -c requirements/constraints.txt, -r requirements/test.txt
 mysqlclient==1.4.6        # via -r requirements/test.txt
-pbr==5.4.5                # via -r requirements/test.txt, stevedore
+pbr==5.5.0                # via -r requirements/test.txt, stevedore
 pycparser==2.20           # via cffi
-pymongo==3.10.1           # via -r requirements/test.txt, edx-opaque-keys
+pymongo==3.11.0           # via -r requirements/test.txt, edx-opaque-keys
 pyopenssl==19.1.0         # via urllib3
-python-dateutil==2.8.1    # via -r requirements/test.txt
+python-dateutil==2.8.1    # via -r requirements/test.txt, botocore
 pytz==2020.1              # via -r requirements/test.txt, apscheduler, celery, django, django-ses, tzlocal
 redis==3.5.3              # via -r requirements/test.txt
 requests==2.24.0          # via -r requirements/test.txt, coveralls
+s3transfer==0.3.3         # via -r requirements/test.txt, boto3
 six==1.15.0               # via -r requirements/test.txt, apscheduler, cryptography, django-configurations, edx-opaque-keys, logilab-common, mock, pyopenssl, python-dateutil, stevedore
 stevedore==1.32.0         # via -r requirements/test.txt, edx-opaque-keys
 tzlocal==2.1              # via -r requirements/test.txt, apscheduler
-urllib3[secure]==1.25.9   # via -r requirements/test.txt, coveralls, requests
+urllib3[secure]==1.25.10  # via -r requirements/test.txt, botocore, coveralls, requests
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools


### PR DESCRIPTION
Amazon's SES is making a change on October 1st that will cause any email sent to this service via the older boto package to fail so we are upgrading `django-ses` package as it is already using `boto3` to send emails since version 1.0.0 [[Reference](https://github.com/django-ses/django-ses/releases/tag/v1.0.0)]

Relevant JIRA : https://openedx.atlassian.net/browse/BOM-2023