### PR TITLE
DEPR-106: Remove from openedx because it's deprecated

### DIFF
--- a/openedx.yaml
+++ b/openedx.yaml
@@ -2,7 +2,6 @@
 # http://open-edx-proposals.readthedocs.io/en/latest/oeps/oep-0002.html#specification
 
 nick: not
-openedx-release: {ref: master}
 oeps:
     oep-7: false
     oep-18: true


### PR DESCRIPTION
Code will be removed from edx-platform later but this doesn't need to be a part of the release.